### PR TITLE
restrict nouns

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,12 +13,12 @@ Nicolas P. Rougier
    :local:
    :depth: 1
 
-Sources are available from `github <https://github.com/rougier/numpy-tutorial>`_.
+Source code of this tutorial is available from `github <https://github.com/rougier/numpy-tutorial>`_.
 
-All code and material is licensed under a `Creative Commons
+This tutorial is licensed under a `Creative Commons
 Attribution-ShareAlike 4.0 <http://creativecommons.org/licenses/by-sa/4.0>`_.
 
-Tutorial can be read at http://www.labri.fr/perso/nrougier/teaching/numpy/numpy.html
+This tutorial can also be read at http://www.labri.fr/perso/nrougier/teaching/numpy/numpy.html
 
 See also:
  * `Matplotlib tutorial <http://www.labri.fr/perso/nrougier/teaching/matplotlib/matplotlib.html>`_


### PR DESCRIPTION
Issue #3 is fixed by this pull request. Nouns after **Table of Contents** are now restricted.